### PR TITLE
fix: gate compat mixins on mixin class name, not target class name

### DIFF
--- a/modules/forge/src/main/java/com/lhwdev/minecraft/railx/mixin/MixinPlugin.java
+++ b/modules/forge/src/main/java/com/lhwdev/minecraft/railx/mixin/MixinPlugin.java
@@ -26,10 +26,10 @@ public class MixinPlugin implements IMixinConfigPlugin {
 	public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
 		if(!mixinClassName.startsWith(mixinPackage)) return true;
 		var index = mixinPackage.length() + 1;
-		if(targetClassName.startsWith("compat.", index)) {
+		if(mixinClassName.startsWith("compat.", index)) {
 			var index2 = index + 7;
-			var index3 = targetClassName.indexOf('.', index2);
-			var compatMod = targetClassName.substring(index2, index3);
+			var index3 = mixinClassName.indexOf('.', index2);
+			var compatMod = mixinClassName.substring(index2, index3);
 			if(!CompatMods.loaded.contains(compatMod)) return false;
 		}
 		return true;


### PR DESCRIPTION
### Problem

`MixinPlugin.shouldApplyMixin` checks `targetClassName` for the `compat.` package segment, but that segment only exists in `mixinClassName`. The condition is therefore never true, the `CompatMods.loaded` gate never runs, and compat mixins are applied unconditionally.

Without Steam 'n' Rails installed, `compat.railways.flexiTrack.TrackTargetingBlockItemMixin` targets a Create class and fails to attach on `CREdgePointTypes.COUPLER`. That takes Create down with it and crashes the game during mod loading:

    Attach error for railx.mixins.json:compat.railways.flexiTrack.TrackTargetingBlockItemMixin
      from mod railx during activity: [... GETSTATIC ->
      com/railwayteam/railways/registry/CREdgePointTypes::COUPLER ...]
    Caused by: java.lang.ClassNotFoundException:
      com.railwayteam.railways.registry.CREdgePointTypes

### Fix

Changed the three `targetClassName` references inside the `compat.` branch to `mixinClassName`. The rest of the logic already matches — the package segment (`railways`) is identical to the mod id in `CompatMods.loaded`.

### Testing

MC 1.21.1 / NeoForge 21.1.248 / Create 6.0.10, RailX 0.2.0-build.14, **without** Steam 'n' Rails installed. Game crashed on startup before the change, loads fine after.

EDIT: i tried to start the mod with Steam 'n' Rails installed and it crashed either btw. 